### PR TITLE
[FEAT] 자기소개서 목록/상세 조회 및 수정 기능 추가

### DIFF
--- a/src/main/java/com/goormthon/samsamejo/config/SecurityConfig.java
+++ b/src/main/java/com/goormthon/samsamejo/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 .sessionManagement(auth -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/recruitments/**", "/api/v1/user-recruitments/**").permitAll()
                         .requestMatchers(Constant.ADMIN_ONLY_URLS.toArray(new String[0])).hasRole("ADMIN")
                         .requestMatchers(Constant.USER_AUTH_URLS.toArray(new String[0])).hasAnyRole("USER", "ADMIN")
                         .requestMatchers(Constant.PERMIT_ALL_URLS.toArray(new String[0])).permitAll()

--- a/src/main/java/com/goormthon/samsamejo/controller/RecruitmentController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/RecruitmentController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -105,7 +106,18 @@ public class RecruitmentController {
             @PathVariable @Min(0) Long recruitmentId,
             @RequestBody RecruitmentEssayWriteRequest request
     ) {
-        essayService.writeEssays(recruitmentId, request);
+        // JWTAuthenticationFilter에서 principal에 userId(Long) 저장됨
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long userId = null;
+        if (principal instanceof String && principal.equals("anonymousUser")) {
+            // 테스트용 임시 userId
+            userId = 1L;
+        } else {
+            userId = Long.valueOf(principal.toString());
+        }
+
+        essayService.writeEssays(userId, recruitmentId, request);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
+
 }

--- a/src/main/java/com/goormthon/samsamejo/controller/ResumeController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/ResumeController.java
@@ -1,0 +1,54 @@
+package com.goormthon.samsamejo.controller;
+
+import com.goormthon.samsamejo.dto.request.ResumeUpdateRequest;
+import com.goormthon.samsamejo.dto.response.ApiResponse;
+import com.goormthon.samsamejo.dto.response.ResumeDetailResponse;
+import com.goormthon.samsamejo.dto.response.ResumeListResponse;
+import com.goormthon.samsamejo.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/user-recruitments")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    /**
+     * 1. 자기소개서 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<ResumeListResponse>> getUserResumes(
+            @RequestHeader("X-USER-ID") Long userId
+    ) {
+        ResumeListResponse data = resumeService.getUserResumes(userId);
+        return ResponseEntity.ok(ApiResponse.ok(data));
+    }
+
+    /**
+     * 2. 특정 자기소개서 상세 조회
+     */
+    @GetMapping("/{userRecruitmentId}")
+    public ResponseEntity<ApiResponse<ResumeDetailResponse>> getUserResumeDetail(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long userRecruitmentId
+    ) {
+        ResumeDetailResponse data = resumeService.getUserResumeDetail(userId, userRecruitmentId);
+        return ResponseEntity.ok(ApiResponse.ok(data));
+    }
+
+    /**
+     * 3. 자기소개서 수정/저장
+     */
+    @PutMapping("/{userRecruitmentId}")
+    public ResponseEntity<ApiResponse<Void>> updateUserResume(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long userRecruitmentId,
+            @RequestBody ResumeUpdateRequest request
+    ) {
+        resumeService.updateUserResume(userId, userRecruitmentId, request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/domain/Essay.java
+++ b/src/main/java/com/goormthon/samsamejo/domain/Essay.java
@@ -1,9 +1,13 @@
 package com.goormthon.samsamejo.domain;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 @Entity
 @Table(name = "essays")
@@ -16,16 +20,20 @@ public class Essay {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;   // essayId
+    @Column(name = "essay_id")
+    private Long id;   // 답변 ID
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id", nullable = false)
     private Question question;   // 연결된 질문
 
-    // TODO: User 연동 시 활성화
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @JoinColumn(name = "user_id", nullable = false)
-    // private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;          // 작성한 유저
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_recruitment_id", nullable = false)
+    private UserRecruitment userRecruitment; // 속한 자기소개서(이력서)
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;  // 사용자가 작성한 자기소개서 답변
@@ -40,12 +48,52 @@ public class Essay {
     @Column(columnDefinition = "TEXT")
     private String suggestion;
 
-    private String tags;
+    @Column(columnDefinition = "TEXT")
+    private String tags; // JSON 문자열로 저장되는 태그 목록
 
-    @Builder.Default
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // ===== Lifecycle Callbacks =====
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // ===== Helper Methods =====
+    /**
+     * tags(JSON 문자열) → List<String> 변환
+     */
+    public List<String> getTagsAsList() {
+        if (tags == null || tags.isBlank()) {
+            return List.of();
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(tags, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * tags 리스트 → JSON 문자열 저장
+     */
+    public void setTagsFromList(List<String> tagList) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            this.tags = mapper.writeValueAsString(tagList);
+        } catch (Exception e) {
+            this.tags = "[]";
+        }
+    }
 }

--- a/src/main/java/com/goormthon/samsamejo/domain/UserRecruitment.java
+++ b/src/main/java/com/goormthon/samsamejo/domain/UserRecruitment.java
@@ -1,0 +1,41 @@
+package com.goormthon.samsamejo.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "user_recruitments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserRecruitment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_recruitment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private Recruitment recruitment;
+
+    @OneToMany(mappedBy = "userRecruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Essay> essays = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/request/ResumeUpdateRequest.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/request/ResumeUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.goormthon.samsamejo.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ResumeUpdateRequest {
+    private List<EssayUpdateRequest> essays;
+
+    @Getter
+    @Setter
+    public static class EssayUpdateRequest {
+        private Long questionId;      // 질문 ID
+        private Long essayId;         // 답변 ID (수정 시 필요, 신규면 null)
+        private String essayContent;  // 답변 내용
+        private List<String> tags;    // 태그 리스트
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ResumeDetailResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ResumeDetailResponse.java
@@ -1,0 +1,26 @@
+package com.goormthon.samsamejo.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ResumeDetailResponse {
+    private Long recruitmentId;
+    private List<QuestionWithEssay> questions;
+
+    @Getter
+    @Builder
+    public static class QuestionWithEssay {
+        private Long questionId;
+        private String questionContent;
+        private Integer minLength;
+        private Integer maxLength;
+        private Boolean required;
+        private Long essayId;
+        private String essayContent;
+        private List<String> tags;
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ResumeListResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ResumeListResponse.java
@@ -1,0 +1,34 @@
+package com.goormthon.samsamejo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResumeListResponse {
+
+    private List<ResumeSummary> totalUserRecruitments;
+    private List<ResumeSummary> completeUserRecruitments;
+    private List<ResumeSummary> progressingUserRecruitments;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResumeSummary {
+        private Long userRecruitmentId;
+        private String company;
+        private String title;
+        private String writeStatus;
+        private int progress;
+        private int essayCount;
+        private int questionCount;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private LocalDate modifiedAt;
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/exception/ErrorCode.java
+++ b/src/main/java/com/goormthon/samsamejo/exception/ErrorCode.java
@@ -31,8 +31,12 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, 4040, "존재하지 않는 사용자입니다"),
     NOT_FOUND_FILE_PATH(HttpStatus.NOT_FOUND, 4041, "존재하지 않는 파일 경로입니다"),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 4042, "존재하지 않는 요청 경로입니다."),
+    NOT_FOUND_USER_RECRUITMENT(HttpStatus.NOT_FOUND, 4043, "존재하지 않는 자기소개서입니다."),
     NOT_FOUND_RECRUITMENT(HttpStatus.NOT_FOUND, 4003, "존재하지 않는 채용 공고입니다"),
     NOT_FOUND_QUESTION(HttpStatus.NOT_FOUND, 4004, "존재하지 않는 질문입니다"),
+
+    // Permission Error
+    FORBIDDEN(HttpStatus.FORBIDDEN, 4030, "권한이 없습니다."),
 
     // Server, File Up/DownLoad Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부에 에러가 발생했습니다."),

--- a/src/main/java/com/goormthon/samsamejo/repository/EssayRepository.java
+++ b/src/main/java/com/goormthon/samsamejo/repository/EssayRepository.java
@@ -4,11 +4,24 @@ import com.goormthon.samsamejo.domain.Essay;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface EssayRepository extends JpaRepository<Essay, Long> {
 
-    // TODO: User 연동 시 활성화
-    // Optional<Essay> findByUser_IdAndQuestion_Id(Long userId, Long questionId);
+    /**
+     * 특정 유저 + 질문 조합으로 작성한 답변 조회
+     */
+    Optional<Essay> findByUser_IdAndQuestion_Id(Long userId, Long questionId);
+
+    /**
+     * 특정 자기소개서(UserRecruitment)에 속한 모든 답변 조회
+     */
+    List<Essay> findAllByUserRecruitment_Id(Long userRecruitmentId);
+
+    /**
+     * 특정 유저가 특정 자기소개서(UserRecruitment) 안에서 작성한 모든 답변 조회
+     */
+    List<Essay> findAllByUser_IdAndUserRecruitment_Id(Long userId, Long userRecruitmentId);
 }

--- a/src/main/java/com/goormthon/samsamejo/repository/UserRecruitmentRepository.java
+++ b/src/main/java/com/goormthon/samsamejo/repository/UserRecruitmentRepository.java
@@ -1,0 +1,12 @@
+package com.goormthon.samsamejo.repository;
+
+import com.goormthon.samsamejo.domain.UserRecruitment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserRecruitmentRepository extends JpaRepository<UserRecruitment, Long> {
+    List<UserRecruitment> findAllByUser_Id(Long userId);
+}

--- a/src/main/java/com/goormthon/samsamejo/service/EssayService.java
+++ b/src/main/java/com/goormthon/samsamejo/service/EssayService.java
@@ -2,13 +2,11 @@ package com.goormthon.samsamejo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.goormthon.samsamejo.domain.Essay;
-import com.goormthon.samsamejo.domain.Question;
+import com.goormthon.samsamejo.domain.*;
 import com.goormthon.samsamejo.dto.request.RecruitmentEssayWriteRequest;
-import com.goormthon.samsamejo.exception.RestException;
 import com.goormthon.samsamejo.exception.ErrorCode;
-import com.goormthon.samsamejo.repository.EssayRepository;
-import com.goormthon.samsamejo.repository.QuestionRepository;
+import com.goormthon.samsamejo.exception.RestException;
+import com.goormthon.samsamejo.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,39 +17,58 @@ public class EssayService {
 
     private final EssayRepository essayRepository;
     private final QuestionRepository questionRepository;
+    private final UsersRepository userRepository;
+    private final UserRecruitmentRepository userRecruitmentRepository;
+    private final RecruitmentRepository recruitmentRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * 자기소개서 작성/수정
+     * @param userId        작성자 유저 ID (JWT에서 추출)
      * @param recruitmentId 채용 공고 ID
-     * @param request 사용자 작성 요청
+     * @param request       사용자 작성 요청
      */
     @Transactional
-    public void writeEssays(Long recruitmentId, /* Long userId, */ RecruitmentEssayWriteRequest request) {
-        // TODO: User 연동 시 활성화
-        // User user = userRepository.findById(userId)
-        //         .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_USER));
+    public void writeEssays(Long userId, Long recruitmentId, RecruitmentEssayWriteRequest request) {
+        // 유저 확인
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_USER));
 
+        // 채용 공고 확인
+        Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
+                .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_RECRUITMENT));
+
+        // 기존 자기소개서(UserRecruitment) 확인 or 새로 생성
+        UserRecruitment userRecruitment;
+        if (request.getUserRecruitmentId() != null) {
+            userRecruitment = userRecruitmentRepository.findById(request.getUserRecruitmentId())
+                    .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_RECRUITMENT));
+        } else {
+            userRecruitment = UserRecruitment.builder()
+                    .user(user)
+                    .recruitment(recruitment)
+                    .build();
+            userRecruitmentRepository.save(userRecruitment);
+        }
+
+        // 문항별 답변 저장
         request.getEssays().forEach(essayReq -> {
             Question question = questionRepository.findById(essayReq.getQuestionId())
                     .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_QUESTION));
 
-            String content = essayReq.getEssayContent();
-            if (content == null || content.isBlank()) {
-                throw new RestException(ErrorCode.INVALID_INPUT_VALUE);
-            }
-
-            // 현재는 user 연동이 없으므로 question 기준으로만 에세이를 가져옴
-            Essay essay = question.getEssays().isEmpty() ? null : question.getEssays().get(0);
+            Essay essay = essayRepository.findByUser_IdAndQuestion_Id(userId, essayReq.getQuestionId())
+                    .orElse(null);
 
             if (essay == null) {
                 essay = Essay.builder()
+                        .user(user)
+                        .userRecruitment(userRecruitment)
                         .question(question)
-                        .content(content)
+                        .content(essayReq.getEssayContent())
                         .tags(convertTagsToJson(essayReq.getTags()))
                         .build();
             } else {
-                essay.setContent(content);
+                essay.setContent(essayReq.getEssayContent());
                 essay.setTags(convertTagsToJson(essayReq.getTags()));
             }
 

--- a/src/main/java/com/goormthon/samsamejo/service/ResumeService.java
+++ b/src/main/java/com/goormthon/samsamejo/service/ResumeService.java
@@ -1,0 +1,170 @@
+package com.goormthon.samsamejo.service;
+
+import com.goormthon.samsamejo.domain.Essay;
+import com.goormthon.samsamejo.domain.Question;
+import com.goormthon.samsamejo.domain.UserRecruitment;
+import com.goormthon.samsamejo.dto.request.ResumeUpdateRequest;
+import com.goormthon.samsamejo.dto.response.ResumeDetailResponse;
+import com.goormthon.samsamejo.dto.response.ResumeListResponse;
+import com.goormthon.samsamejo.exception.ErrorCode;
+import com.goormthon.samsamejo.exception.RestException;
+import com.goormthon.samsamejo.repository.EssayRepository;
+import com.goormthon.samsamejo.repository.QuestionRepository;
+import com.goormthon.samsamejo.repository.UserRecruitmentRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+
+    private final UserRecruitmentRepository userRecruitmentRepository;
+    private final QuestionRepository questionRepository;
+    private final EssayRepository essayRepository;
+
+    /**
+     * 자기소개서 목록 조회 (요약)
+     */
+    public ResumeListResponse getUserResumes(Long userId) {
+        List<UserRecruitment> userRecruitments = userRecruitmentRepository.findAllByUser_Id(userId);
+
+        List<ResumeListResponse.ResumeSummary> total = userRecruitments.stream().map(ur -> {
+            Long recruitmentId = ur.getRecruitment().getId();
+
+            // 전체 문항 수
+            List<Question> questions = questionRepository.findByRecruitment_Id(recruitmentId);
+            int questionCount = questions.size();
+
+            // 작성된 답변 수 (현재 유저가 작성한 Essay만 카운트)
+            List<Essay> essays = ur.getEssays().stream()
+                    .filter(e -> e.getUser().getId().equals(userId))
+                    .toList();
+            int essayCount = essays.size();
+
+            // 진행률
+            int progress = questionCount == 0 ? 0 : (essayCount * 100 / questionCount);
+            String status = (progress == 100) ? "COMPLETE" : "PROGRESS";
+
+            // 마지막 수정일 (Essay.updatedAt 중 가장 최근 값, 없으면 UserRecruitment.createdAt)
+            LocalDate modifiedAt = essays.stream()
+                    .map(e -> e.getUpdatedAt() != null
+                            ? e.getUpdatedAt().toLocalDate()
+                            : e.getCreatedAt().toLocalDate())
+                    .max(Comparator.naturalOrder())
+                    .orElse(ur.getCreatedAt().toLocalDate());
+
+            return ResumeListResponse.ResumeSummary.builder()
+                    .userRecruitmentId(ur.getId())
+                    .company(ur.getRecruitment().getCompanyName())
+                    .title(ur.getRecruitment().getTitle())
+                    .writeStatus(status)
+                    .progress(progress)
+                    .essayCount(essayCount)
+                    .questionCount(questionCount)
+                    .modifiedAt(modifiedAt)
+                    .build();
+        }).collect(Collectors.toList());
+
+        List<ResumeListResponse.ResumeSummary> complete = total.stream()
+                .filter(r -> r.getWriteStatus().equals("COMPLETE"))
+                .collect(Collectors.toList());
+
+        List<ResumeListResponse.ResumeSummary> progressing = total.stream()
+                .filter(r -> r.getWriteStatus().equals("PROGRESS"))
+                .collect(Collectors.toList());
+
+        return ResumeListResponse.builder()
+                .totalUserRecruitments(total)
+                .completeUserRecruitments(complete)
+                .progressingUserRecruitments(progressing)
+                .build();
+    }
+
+    /**
+     * 특정 자기소개서 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public ResumeDetailResponse getUserResumeDetail(Long userId, Long userRecruitmentId) {
+        // UserRecruitment 확인
+        UserRecruitment userRecruitment = userRecruitmentRepository.findById(userRecruitmentId)
+                .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_USER_RECRUITMENT));
+
+        // 본인 소유 검사
+        if (!userRecruitment.getUser().getId().equals(userId)) {
+            throw new RestException(ErrorCode.FORBIDDEN); // 권한 없음
+        }
+
+        Long recruitmentId = userRecruitment.getRecruitment().getId();
+
+        // 해당 공고의 질문들
+        List<Question> questions = questionRepository.findByRecruitment_Id(recruitmentId);
+
+        // 답변 매핑
+        List<ResumeDetailResponse.QuestionWithEssay> questionDtos = questions.stream()
+                .map(q -> {
+                    Essay essay = userRecruitment.getEssays().stream()
+                            .filter(e -> e.getQuestion().getId().equals(q.getId()))
+                            .findFirst()
+                            .orElse(null);
+
+                    return ResumeDetailResponse.QuestionWithEssay.builder()
+                            .questionId(q.getId())
+                            .questionContent(q.getContent())
+                            .minLength(q.getMinLength())
+                            .maxLength(q.getMaxLength())
+                            .required(q.getRequired())
+                            .essayId(essay != null ? essay.getId() : null)
+                            .essayContent(essay != null ? essay.getContent() : "")
+                            .tags(essay != null ? essay.getTagsAsList() : List.of())
+                            .build();
+                })
+                .toList();
+
+        return ResumeDetailResponse.builder()
+                .recruitmentId(recruitmentId)
+                .questions(questionDtos)
+                .build();
+    }
+
+    @Transactional
+    public void updateUserResume(Long userId, Long userRecruitmentId, ResumeUpdateRequest request) {
+        UserRecruitment userRecruitment = userRecruitmentRepository.findById(userRecruitmentId)
+                .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_USER_RECRUITMENT));
+
+        if (!userRecruitment.getUser().getId().equals(userId)) {
+            throw new RestException(ErrorCode.FORBIDDEN);
+        }
+
+        for (ResumeUpdateRequest.EssayUpdateRequest essayReq : request.getEssays()) {
+            // 질문 확인
+            Question question = questionRepository.findById(essayReq.getQuestionId())
+                    .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_QUESTION));
+
+            Essay essay;
+            if (essayReq.getEssayId() != null) {
+                // 기존 답변 수정
+                essay = essayRepository.findById(essayReq.getEssayId())
+                        .orElseThrow(() -> new RestException(ErrorCode.NOT_FOUND_QUESTION));
+
+                essay.setContent(essayReq.getEssayContent());
+                essay.setTagsFromList(essayReq.getTags());
+            } else {
+                // 새 답변 추가
+                essay = Essay.builder()
+                        .user(userRecruitment.getUser())
+                        .userRecruitment(userRecruitment)
+                        .question(question)
+                        .content(essayReq.getEssayContent())
+                        .build();
+                essay.setTagsFromList(essayReq.getTags());
+            }
+            essayRepository.save(essay);
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## ⚒️ Changes
- 자기소개서 목록 조회 API 구현 (`GET /api/v1/user-recruitments`)
- 자기소개서 상세 조회 API 구현 (`GET /api/v1/user-recruitments/{userRecruitmentId}`)
- 자기소개서 수정/저장 API 구현 (`PUT /api/v1/user-recruitments/{userRecruitmentId}`)
- `ErrorCode`에 `NOT_FOUND_USER_RECRUITMENT`, `FORBIDDEN` 코드 추가
- `Essay` 엔티티에 `tags` JSON 직렬화/역직렬화 메서드 추가

## ✂️ Problem
- JWT 토큰 검증 로직과 `X-USER-ID` 헤더 사용 방식이 혼재되어 있어 개선 필요
- Postman 테스트 시 헤더 누락 시 `MissingRequestHeaderException` 발생 (구조 개선 고려)

## ⚒️ ETC
- 현재는 `X-USER-ID` 헤더를 통해 사용자 식별, 추후 SecurityContext 기반으로 리팩토링 권장