### PR TITLE
feat: 아카이브 API 구현 (목록 조회, 상세 조회, 피드백 조회)

### DIFF
--- a/src/main/java/com/goormthon/samsamejo/config/SecurityConfig.java
+++ b/src/main/java/com/goormthon/samsamejo/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 .sessionManagement(auth -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/recruitments/**", "/api/v1/user-recruitments/**").permitAll()
+                        .requestMatchers("/api/v1/recruitments/**", "/api/v1/user-recruitments/**", "/api/v1/archives/**").permitAll()
                         .requestMatchers(Constant.ADMIN_ONLY_URLS.toArray(new String[0])).hasRole("ADMIN")
                         .requestMatchers(Constant.USER_AUTH_URLS.toArray(new String[0])).hasAnyRole("USER", "ADMIN")
                         .requestMatchers(Constant.PERMIT_ALL_URLS.toArray(new String[0])).permitAll()

--- a/src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
@@ -1,0 +1,68 @@
+// src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
+package com.goormthon.samsamejo.controller;
+
+import com.goormthon.samsamejo.dto.response.ArchiveEssayDetailResponse;
+import com.goormthon.samsamejo.dto.response.ArchiveEssayFeedbackResponse;
+import com.goormthon.samsamejo.dto.response.ArchiveResponse;
+import com.goormthon.samsamejo.dto.response.ApiResponse;
+import com.goormthon.samsamejo.service.ArchiveService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/archives")
+public class ArchiveController {
+
+    private final ArchiveService archiveService;
+
+    public ArchiveController(ArchiveService archiveService) {
+        this.archiveService = archiveService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ArchiveResponse>> getArchives(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String search,
+            @RequestParam(defaultValue = "RECENT") String order,
+            @RequestHeader(value = "X-USER-ID", required = false) Long userId
+    ) {
+        Sort sort;
+        switch (order.toUpperCase()) {
+            case "OLDEST":
+                sort = Sort.by(Sort.Direction.ASC, "createdAt");
+                break;
+            default: // RECENT
+                sort = Sort.by(Sort.Direction.DESC, "updatedAt");
+        }
+
+        PageRequest pageable = PageRequest.of(page - 1, 10, sort);
+        ArchiveResponse response = archiveService.getArchives(userId, search, pageable);
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{essayId}")
+    public ResponseEntity<ApiResponse<ArchiveEssayDetailResponse>> getArchiveDetail(
+            @PathVariable Long essayId
+    ) {
+        ArchiveEssayDetailResponse response = archiveService.getArchiveDetail(essayId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{essayId}/feedbacks")
+    public ResponseEntity<ApiResponse<Map<String, List<ArchiveEssayFeedbackResponse>>>> getEssayFeedbacks(
+            @PathVariable Long essayId
+    ) {
+        List<ArchiveEssayFeedbackResponse> feedbacks = archiveService.getEssayFeedbacks(essayId);
+        Map<String, List<ArchiveEssayFeedbackResponse>> data = new HashMap<>();
+        data.put("feedbacks", feedbacks);
+
+        return ResponseEntity.ok(ApiResponse.ok(data));
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayDetailResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayDetailResponse.java
@@ -1,0 +1,69 @@
+package com.goormthon.samsamejo.dto.response;
+
+import com.goormthon.samsamejo.domain.Essay;
+import com.goormthon.samsamejo.repository.EssayRepository;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ArchiveEssayDetailResponse {
+    private Long questionId;          // 질문 ID
+    private String content;           // 질문 본문
+    private String questionCategory;  // 질문 카테고리 (임시 매핑)
+    private String createdAt;         // 최초 작성일
+    private String currentUseDate;    // 최근 사용일
+    private int useCount;             // 사용 횟수
+    private int length;               // 글자 수
+    private Long essayId;             // 답변 ID
+    private String essayContent;      // 답변 본문
+    private List<String> companies;   // 재사용된 기업명
+    private List<String> tags;        // 태그 목록
+
+    public static ArchiveEssayDetailResponse fromEntity(Essay essay, EssayRepository essayRepository) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        // 사용 횟수 = 같은 질문 + 동일 답변 내용 에세이 개수
+        int useCount = essayRepository.countByQuestion_IdAndContent(
+                essay.getQuestion().getId(),
+                essay.getContent()
+        );
+
+        // 사용 기업 목록
+        List<String> companies = essayRepository.findAllByQuestion_IdAndContent(
+                        essay.getQuestion().getId(),
+                        essay.getContent()
+                ).stream()
+                .map(e -> e.getUserRecruitment().getRecruitment().getCompanyName())
+                .distinct()
+                .collect(Collectors.toList());
+
+        // 카테고리 임시 매핑
+        String questionCategory = mapCategory(essay.getQuestion().getContent());
+
+        return ArchiveEssayDetailResponse.builder()
+                .questionId(essay.getQuestion().getId())
+                .content(essay.getQuestion().getContent())
+                .questionCategory(questionCategory)
+                .createdAt(essay.getCreatedAt() != null ? essay.getCreatedAt().format(formatter) : null)
+                .currentUseDate(essay.getUpdatedAt() != null ? essay.getUpdatedAt().format(formatter) : null)
+                .useCount(useCount)
+                .length(essay.getContent() != null ? essay.getContent().length() : 0)
+                .essayId(essay.getId())
+                .essayContent(essay.getContent())
+                .companies(companies)
+                .tags(essay.getTagsAsList())
+                .build();
+    }
+
+    private static String mapCategory(String content) {
+        if (content.contains("지원동기")) return "지원동기";
+        if (content.contains("경험") || content.contains("성과")) return "경험/역량";
+        if (content.contains("성격") || content.contains("장단점")) return "성격/장단점";
+        return "기타";
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayFeedbackResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayFeedbackResponse.java
@@ -1,0 +1,33 @@
+package com.goormthon.samsamejo.dto.response;
+
+import com.goormthon.samsamejo.domain.Essay;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ArchiveEssayFeedbackResponse {
+    private int sequence;             // 피드백 순번
+    private String questionContent;   // 질문 내용
+    private String essayContent;      // 답변 내용
+    private String goodTitle;         // 장점 타이틀
+    private String goodContent;       // 장점 내용
+    private String badTitle;          // 단점 타이틀
+    private String badContent;        // 단점 내용
+    private String suggestionTitle;   // 제안 타이틀
+    private String suggestionContent; // 제안 내용
+
+    public static ArchiveEssayFeedbackResponse fromEntity(Essay essay) {
+        return ArchiveEssayFeedbackResponse.builder()
+                .sequence(1) // 단일 feedback → 항상 1, 추후 확장 가능
+                .questionContent(essay.getQuestion().getContent())
+                .essayContent(essay.getContent())
+                .goodTitle("잘한 점") // 필요하면 AI가 따로 세분화
+                .goodContent(essay.getGood())
+                .badTitle("아쉬운 점")
+                .badContent(essay.getBad())
+                .suggestionTitle("개선 제안")
+                .suggestionContent(essay.getSuggestion())
+                .build();
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayResponse.java
@@ -1,0 +1,75 @@
+// src/main/java/com/goormthon/samsamejo/dto/response/ArchiveEssayResponse.java
+package com.goormthon.samsamejo.dto.response;
+
+import com.goormthon.samsamejo.domain.Essay;
+import com.goormthon.samsamejo.repository.EssayRepository;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ArchiveEssayResponse {
+    private Long recruitmentId;
+    private Long questionId;
+    private Long essayId;
+    private String questionCategory;
+    private int reuseCount;
+    private String currentUseDate;
+    private String questionContent;
+    private String essayContent;
+    private List<String> applyCompanies;
+    private List<String> tags;
+
+    public static ArchiveEssayResponse fromEntity(Essay essay, EssayRepository essayRepository) {
+        // ===== 날짜 포맷 =====
+        String currentUseDate = null;
+        if (essay.getUpdatedAt() != null) {
+            currentUseDate = essay.getUpdatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        }
+
+        // ===== 재사용 횟수 =====
+        int reuseCount = essayRepository.countByQuestion_IdAndContent(
+                essay.getQuestion().getId(),
+                essay.getContent()
+        );
+
+        // ===== 재사용 기업 목록 =====
+        List<String> applyCompanies = essayRepository.findAllByQuestion_IdAndContent(
+                        essay.getQuestion().getId(),
+                        essay.getContent()
+                ).stream()
+                .map(e -> e.getUserRecruitment().getRecruitment().getCompanyName())
+                .distinct()
+                .collect(Collectors.toList());
+
+        // ===== 임시 질문 카테고리 =====
+        String questionCategory = mapCategory(essay.getQuestion().getContent());
+
+        return ArchiveEssayResponse.builder()
+                .recruitmentId(essay.getQuestion().getRecruitment().getId())
+                .questionId(essay.getQuestion().getId())
+                .essayId(essay.getId())
+                .questionCategory(questionCategory)
+                .reuseCount(reuseCount)
+                .currentUseDate(currentUseDate)
+                .questionContent(essay.getQuestion().getContent())
+                .essayContent(essay.getContent())
+                .applyCompanies(applyCompanies)
+                .tags(essay.getTagsAsList())
+                .build();
+    }
+
+    /**
+     * 임시 카테고리 매핑 로직 (content 기반 키워드 매칭)
+     */
+    private static String mapCategory(String content) {
+        if (content.contains("지원동기")) return "지원동기";
+        if (content.contains("경험") || content.contains("성과")) return "경험/역량";
+        if (content.contains("성격") || content.contains("장단점")) return "성격/장단점";
+        return "기타";
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/ArchiveResponse.java
@@ -1,0 +1,35 @@
+package com.goormthon.samsamejo.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ArchiveResponse {
+    private int savedEssayCount;        // 저장된 답변 수
+    private int reuseCount;             // 전체 재사용 횟수
+    private int recuitmentApplyCount;   // 지원 기업 수
+    private List<ArchiveEssayResponse> essays;
+    private PageInfo pageInfo;
+
+    @Getter
+    @Builder
+    public static class PageInfo {
+        private int page;
+        private int size;
+        private long totalElements;
+        private int totalPages;
+
+        public static PageInfo from(Page<?> page) {
+            return PageInfo.builder()
+                    .page(page.getNumber() + 1)
+                    .size(page.getSize())
+                    .totalElements(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/goormthon/samsamejo/repository/EssayRepository.java
+++ b/src/main/java/com/goormthon/samsamejo/repository/EssayRepository.java
@@ -1,6 +1,8 @@
 package com.goormthon.samsamejo.repository;
 
 import com.goormthon.samsamejo.domain.Essay;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +11,8 @@ import java.util.Optional;
 
 @Repository
 public interface EssayRepository extends JpaRepository<Essay, Long> {
+
+    // ================= 기본 조회 =================
 
     /**
      * 특정 유저 + 질문 조합으로 작성한 답변 조회
@@ -24,4 +28,30 @@ public interface EssayRepository extends JpaRepository<Essay, Long> {
      * 특정 유저가 특정 자기소개서(UserRecruitment) 안에서 작성한 모든 답변 조회
      */
     List<Essay> findAllByUser_IdAndUserRecruitment_Id(Long userId, Long userRecruitmentId);
+
+    // ================= 아카이브 조회 =================
+
+    /**
+     * 특정 유저의 전체 답변 (페이징)
+     */
+    Page<Essay> findAllByUser_Id(Long userId, Pageable pageable);
+
+    /**
+     * 특정 유저의 답변 + 검색 (content OR question.content)
+     */
+    Page<Essay> findByUser_IdAndContentContainingOrUser_IdAndQuestion_ContentContaining(
+            Long userId1, String content,
+            Long userId2, String questionContent,
+            Pageable pageable
+    );
+
+    /**
+     * 같은 질문 + 같은 답변 내용을 가진 에세이 개수 (재사용 횟수 계산용)
+     */
+    int countByQuestion_IdAndContent(Long questionId, String content);
+
+    /**
+     * 같은 질문 + 같은 답변 내용을 가진 모든 에세이 (재사용 기업 목록 조회용)
+     */
+    List<Essay> findAllByQuestion_IdAndContent(Long questionId, String content);
 }

--- a/src/main/java/com/goormthon/samsamejo/service/ArchiveService.java
+++ b/src/main/java/com/goormthon/samsamejo/service/ArchiveService.java
@@ -1,0 +1,90 @@
+// src/main/java/com/goormthon/samsamejo/service/ArchiveService.java
+package com.goormthon.samsamejo.service;
+
+import com.goormthon.samsamejo.domain.Essay;
+import com.goormthon.samsamejo.dto.response.ArchiveEssayDetailResponse;
+import com.goormthon.samsamejo.dto.response.ArchiveEssayFeedbackResponse;
+import com.goormthon.samsamejo.dto.response.ArchiveEssayResponse;
+import com.goormthon.samsamejo.dto.response.ArchiveResponse;
+import com.goormthon.samsamejo.repository.EssayRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ArchiveService {
+
+    private final EssayRepository essayRepository;
+
+    public ArchiveService(EssayRepository essayRepository) {
+        this.essayRepository = essayRepository;
+    }
+
+    /**
+     * 특정 유저의 아카이브 목록 조회
+     */
+    public ArchiveResponse getArchives(Long userId, String search, Pageable pageable) {
+        Page<Essay> essays;
+
+        if (search == null || search.isBlank()) {
+            essays = essayRepository.findAllByUser_Id(userId, pageable);
+        } else {
+            essays = essayRepository.findByUser_IdAndContentContainingOrUser_IdAndQuestion_ContentContaining(
+                    userId, search,
+                    userId, search,
+                    pageable
+            );
+        }
+
+        // 전체 재사용 횟수 합산
+        int totalReuseCount = essays.stream()
+                .mapToInt(e -> essayRepository.countByQuestion_IdAndContent(
+                        e.getQuestion().getId(),
+                        e.getContent()
+                ))
+                .sum();
+
+        // 지원 기업 수 (distinct companyName)
+        long applyCompanyCount = essays.stream()
+                .flatMap(e -> essayRepository.findAllByQuestion_IdAndContent(
+                                e.getQuestion().getId(),
+                                e.getContent()
+                        ).stream()
+                        .map(e2 -> e2.getUserRecruitment().getRecruitment().getCompanyName()))
+                .distinct()
+                .count();
+
+        // Essay DTO 변환 (reuseCount, applyCompanies 포함)
+        List<ArchiveEssayResponse> essayResponses = essays.stream()
+                .map(e -> ArchiveEssayResponse.fromEntity(e, essayRepository))
+                .collect(Collectors.toList());
+
+        return ArchiveResponse.builder()
+                .savedEssayCount((int) essays.getTotalElements())
+                .reuseCount(totalReuseCount)
+                .recuitmentApplyCount((int) applyCompanyCount)
+                .essays(essayResponses)
+                .pageInfo(ArchiveResponse.PageInfo.from(essays))
+                .build();
+    }
+
+    public ArchiveEssayDetailResponse getArchiveDetail(Long essayId) {
+        Essay essay = essayRepository.findById(essayId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답변입니다. essayId=" + essayId));
+
+        return ArchiveEssayDetailResponse.fromEntity(essay, essayRepository);
+    }
+
+    /**
+     * 특정 답변의 AI 피드백 조회
+     */
+    public List<ArchiveEssayFeedbackResponse> getEssayFeedbacks(Long essayId) {
+        Essay essay = essayRepository.findById(essayId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답변입니다. essayId=" + essayId));
+
+        return List.of(ArchiveEssayFeedbackResponse.fromEntity(essay));
+    }
+}


### PR DESCRIPTION
## ⚒️ Changes  
- 아카이브 **목록 조회 API** (`GET /api/v1/archives`) 구현  
- 아카이브 **답변 상세 조회 API** (`GET /api/v1/archives/{essayId}`) 구현  
- 아카이브 **자기소개서 피드백 조회 API** (`GET /api/v1/archives/{essayId}/feedbacks`) 구현  
- DTO 추가  
  - `ArchiveResponse`, `ArchiveEssayResponse`  
  - `ArchiveEssayDetailResponse`, `ArchiveEssayFeedbackResponse`  
- Service / Controller 로직 작성 및 예외 처리  

---

## ✂️ Problem  
- `Essay` 엔티티의 `good`, `bad`, `suggestion` 필드가 아직 AI 연동 전이라 `null` 반환됨  
- 추후 **Essay 저장 시 AI 서버 연동 로직** 필요  

---

## ⚒️ ETC  
- 임시 `questionCategory` 매핑 로직(content 기반 키워드) 추가  
- `currentUseDate` 날짜 포맷을 `yyyy-MM-dd`로 맞춤  
