### PR TITLE
feat: @UserId 적용 및 권한 제어 추가

### DIFF
--- a/src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
@@ -1,6 +1,7 @@
 // src/main/java/com/goormthon/samsamejo/controller/ArchiveController.java
 package com.goormthon.samsamejo.controller;
 
+import com.goormthon.samsamejo.annotation.UserId;
 import com.goormthon.samsamejo.dto.response.ArchiveEssayDetailResponse;
 import com.goormthon.samsamejo.dto.response.ArchiveEssayFeedbackResponse;
 import com.goormthon.samsamejo.dto.response.ArchiveResponse;
@@ -9,6 +10,7 @@ import com.goormthon.samsamejo.service.ArchiveService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -25,12 +27,13 @@ public class ArchiveController {
         this.archiveService = archiveService;
     }
 
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<ArchiveResponse>> getArchives(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(required = false) String search,
             @RequestParam(defaultValue = "RECENT") String order,
-            @RequestHeader(value = "X-USER-ID", required = false) Long userId
+            @UserId(required = false) Long userId
     ) {
         Sort sort;
         switch (order.toUpperCase()) {
@@ -47,6 +50,7 @@ public class ArchiveController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/{essayId}")
     public ResponseEntity<ApiResponse<ArchiveEssayDetailResponse>> getArchiveDetail(
             @PathVariable Long essayId
@@ -55,6 +59,7 @@ public class ArchiveController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/{essayId}/feedbacks")
     public ResponseEntity<ApiResponse<Map<String, List<ArchiveEssayFeedbackResponse>>>> getEssayFeedbacks(
             @PathVariable Long essayId

--- a/src/main/java/com/goormthon/samsamejo/controller/RecruitmentController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/RecruitmentController.java
@@ -1,5 +1,6 @@
 package com.goormthon.samsamejo.controller;
 
+import com.goormthon.samsamejo.annotation.UserId;
 import com.goormthon.samsamejo.domain.Recruitment;
 import com.goormthon.samsamejo.dto.request.RecruitmentEssayWriteRequest;
 import com.goormthon.samsamejo.dto.response.*;
@@ -12,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -75,6 +77,7 @@ public class RecruitmentController {
     /**
      * 채용 공고 API 연동 (공공데이터포털 → DB 저장)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/fetch")
     public ResponseEntity<Map<String, Object>> fetchRecruitmentsFromApi() {
         int savedCount = recruitmentService.fetchAndSaveFromApi();
@@ -90,6 +93,7 @@ public class RecruitmentController {
     /**
      * 채용 공고 질문 불러오기
      */
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/{recruitmentId}/write")
     public ResponseEntity<ApiResponse<RecruitmentQuestionsResponse>> getRecruitmentQuestions(
             @PathVariable @Min(0) Long recruitmentId) {
@@ -101,21 +105,13 @@ public class RecruitmentController {
     /**
      * 채용 공고 자기소개서 작성
      */
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @PostMapping("/{recruitmentId}/write")
     public ResponseEntity<ApiResponse<Void>> writeEssays(
+            @UserId Long userId,
             @PathVariable @Min(0) Long recruitmentId,
             @RequestBody RecruitmentEssayWriteRequest request
     ) {
-        // JWTAuthenticationFilter에서 principal에 userId(Long) 저장됨
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        Long userId = null;
-        if (principal instanceof String && principal.equals("anonymousUser")) {
-            // 테스트용 임시 userId
-            userId = 1L;
-        } else {
-            userId = Long.valueOf(principal.toString());
-        }
-
         essayService.writeEssays(userId, recruitmentId, request);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }

--- a/src/main/java/com/goormthon/samsamejo/controller/RecruitmentFetchLogController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/RecruitmentFetchLogController.java
@@ -1,3 +1,4 @@
+// src/main/java/com/goormthon/samsamejo/controller/RecruitmentFetchLogController.java
 package com.goormthon.samsamejo.controller;
 
 import com.goormthon.samsamejo.dto.response.RecruitmentStatusResponse;
@@ -14,12 +15,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RecruitmentFetchLogController {
 
+    private static final String NO_LOG_STATUS = "NO_LOG";
+
     private final RecruitmentFetchLogService fetchLogService;
 
+    /**
+     * 최근 채용 공고 수집 실행 상태 조회 (관리자 전용)
+     */
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/status")
     public ResponseEntity<RecruitmentStatusResponse> getLastFetchStatus() {
-        return fetchLogService.getLastLog()
+        RecruitmentStatusResponse response = fetchLogService.getLastLog()
                 .map(log -> RecruitmentStatusResponse.builder()
                         .lastRun(log.getExecutedAt())
                         .status(log.getStatus())
@@ -27,15 +33,14 @@ public class RecruitmentFetchLogController {
                         .updatedJobs(log.getUpdatedCount())
                         .failedJobs(log.getFailedCount())
                         .build())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.ok(
-                        RecruitmentStatusResponse.builder()
-                                .lastRun(null)
-                                .status("NO_LOG")
-                                .newJobs(0)
-                                .updatedJobs(0)
-                                .failedJobs(0)
-                                .build()
-                ));
+                .orElseGet(() -> RecruitmentStatusResponse.builder()
+                        .lastRun(null)
+                        .status(NO_LOG_STATUS)
+                        .newJobs(0)
+                        .updatedJobs(0)
+                        .failedJobs(0)
+                        .build());
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/goormthon/samsamejo/controller/ResumeController.java
+++ b/src/main/java/com/goormthon/samsamejo/controller/ResumeController.java
@@ -1,5 +1,6 @@
 package com.goormthon.samsamejo.controller;
 
+import com.goormthon.samsamejo.annotation.UserId;
 import com.goormthon.samsamejo.dto.request.ResumeUpdateRequest;
 import com.goormthon.samsamejo.dto.response.ApiResponse;
 import com.goormthon.samsamejo.dto.response.ResumeDetailResponse;
@@ -7,6 +8,7 @@ import com.goormthon.samsamejo.dto.response.ResumeListResponse;
 import com.goormthon.samsamejo.service.ResumeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,9 +21,10 @@ public class ResumeController {
     /**
      * 1. 자기소개서 목록 조회
      */
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping
     public ResponseEntity<ApiResponse<ResumeListResponse>> getUserResumes(
-            @RequestHeader("X-USER-ID") Long userId
+            @UserId Long userId
     ) {
         ResumeListResponse data = resumeService.getUserResumes(userId);
         return ResponseEntity.ok(ApiResponse.ok(data));
@@ -30,9 +33,10 @@ public class ResumeController {
     /**
      * 2. 특정 자기소개서 상세 조회
      */
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @GetMapping("/{userRecruitmentId}")
     public ResponseEntity<ApiResponse<ResumeDetailResponse>> getUserResumeDetail(
-            @RequestHeader("X-USER-ID") Long userId,
+            @UserId Long userId,
             @PathVariable Long userRecruitmentId
     ) {
         ResumeDetailResponse data = resumeService.getUserResumeDetail(userId, userRecruitmentId);
@@ -42,9 +46,10 @@ public class ResumeController {
     /**
      * 3. 자기소개서 수정/저장
      */
+    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     @PutMapping("/{userRecruitmentId}")
     public ResponseEntity<ApiResponse<Void>> updateUserResume(
-            @RequestHeader("X-USER-ID") Long userId,
+            @UserId Long userId,
             @PathVariable Long userRecruitmentId,
             @RequestBody ResumeUpdateRequest request
     ) {

--- a/src/main/java/com/goormthon/samsamejo/dto/response/RecruitmentDetailResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/RecruitmentDetailResponse.java
@@ -40,7 +40,7 @@ public class RecruitmentDetailResponse {
                         ? recruitment.getEmploymentType()
                         : "기타")
                 .description(recruitment.getDescription())
-                .skills(recruitment.getSkills() != null ? recruitment.getSkills() : Collections.emptyList())
+                .skills(extractSkills(recruitment.getDescription()))
                 .deadline(recruitment.getDeadline())
                 .createdAt(recruitment.getCreatedAt())
                 .updatedAt(recruitment.getUpdatedAt())
@@ -60,5 +60,33 @@ public class RecruitmentDetailResponse {
             case EXPERIENCED -> List.of("경력");
             case BOTH -> List.of("신입", "경력");
         };
+    }
+
+    /**
+     * description에서 특정 키워드를 찾아서 skills 리스트로 반환
+     */
+    private static List<String> extractSkills(String description) {
+        if (description == null || description.isBlank()) {
+            return List.of("미정");
+        }
+
+        // 기본 키워드 사전
+        String lower = description.toLowerCase();
+        List<String> skills = new java.util.ArrayList<>();
+
+        if (lower.contains("java")) skills.add("Java");
+        if (lower.contains("spring")) skills.add("Spring Boot");
+        if (lower.contains("python")) skills.add("Python");
+        if (lower.contains("django")) skills.add("Django");
+        if (lower.contains("javascript")) skills.add("JavaScript");
+        if (lower.contains("react")) skills.add("React");
+        if (lower.contains("node")) skills.add("Node.js");
+        if (lower.contains("mysql")) skills.add("MySQL");
+        if (lower.contains("postgres")) skills.add("PostgreSQL");
+        if (lower.contains("aws")) skills.add("AWS");
+        if (lower.contains("docker")) skills.add("Docker");
+        if (lower.contains("kubernetes")) skills.add("Kubernetes");
+
+        return skills.isEmpty() ? List.of("미정") : skills;
     }
 }

--- a/src/main/java/com/goormthon/samsamejo/dto/response/RecruitmentListResponse.java
+++ b/src/main/java/com/goormthon/samsamejo/dto/response/RecruitmentListResponse.java
@@ -27,7 +27,7 @@ public class RecruitmentListResponse {
                 .company(recruitment.getCompanyName())
                 .location(recruitment.getLocation())
                 .careers(toKoreanCareers(recruitment.getExperienceLevel()))
-                .skills(Collections.emptyList()) // 아직 스킬 필드 없으므로 빈 배열
+                .skills(extractSkills(recruitment.getDescription()))
                 .deadline(recruitment.getDeadline())
                 .build();
     }
@@ -39,5 +39,33 @@ public class RecruitmentListResponse {
             case EXPERIENCED -> List.of("경력");
             case BOTH -> List.of("신입", "경력");
         };
+    }
+
+    /**
+     * description에서 특정 키워드를 찾아서 skills 리스트로 반환
+     */
+    private static List<String> extractSkills(String description) {
+        if (description == null || description.isBlank()) {
+            return List.of("미정");
+        }
+
+        // 기본 키워드 사전
+        String lower = description.toLowerCase();
+        List<String> skills = new java.util.ArrayList<>();
+
+        if (lower.contains("java")) skills.add("Java");
+        if (lower.contains("spring")) skills.add("Spring Boot");
+        if (lower.contains("python")) skills.add("Python");
+        if (lower.contains("django")) skills.add("Django");
+        if (lower.contains("javascript")) skills.add("JavaScript");
+        if (lower.contains("react")) skills.add("React");
+        if (lower.contains("node")) skills.add("Node.js");
+        if (lower.contains("mysql")) skills.add("MySQL");
+        if (lower.contains("postgres")) skills.add("PostgreSQL");
+        if (lower.contains("aws")) skills.add("AWS");
+        if (lower.contains("docker")) skills.add("Docker");
+        if (lower.contains("kubernetes")) skills.add("Kubernetes");
+
+        return skills.isEmpty() ? List.of("미정") : skills;
     }
 }


### PR DESCRIPTION
## ⚒️Changes
- 기존 @RequestHeader("X-USER-ID"), SecurityContextHolder 방식 제거

- 컨트롤러 전역에 @UserId 애너테이션 적용하여 사용자 식별 통일

- USER / ADMIN 권한 요구 엔드포인트에 접근 제어 로직 추가 (@PreAuthorize, @UserId)

- 토큰 기반 인증이 필요한 API와 공개 API 구분 명확화

## ✂️Problem
- 인증되지 않은 사용자가 접근 시 anonymousUser → NumberFormatException 발생

- 권한 요구사항이 컨트롤러마다 일관되지 않아 관리 어려움

## ⚒️ETC

- FE 요청 시 토큰 필수 반영 필요